### PR TITLE
help invocation.

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ sudo ./multiboot-media-creator.py --isos Fedora-15-Beta-*-Live-*.iso -v \
 --target Fedora-15-Beta-Multi-Boot.iso --targetname Fedora-15-Beta-Multi-Boot
 
 Please note, this is a single line command, I've just split it up to make this 
-README more friendly. If you run multiboot-media-creator.py --help, it will show
+README more friendly. If you run ./multiboot-media-creator.py --help, it will show
 all the valid options. I strongly recommend running with -v.
 
 == TODO List ==


### PR DESCRIPTION
without the  ./ preceeding it  fails to trigger  --help   from ~/Git/multiboot-media-creator/
